### PR TITLE
Fill dotnet projects metadata

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,13 +77,13 @@ jobs:
 
         if [[ $LAST_COMMIT_MESSAGE =~ ^major:.*$ ]]; then
           echo "Bumping to next major version."
-          NEXT_VERSION="v$MAJOR"
+          NEXT_VERSION="$MAJOR"
         elif [[ $LAST_COMMIT_MESSAGE =~ ^feat:.*$ ]]; then
           echo "Bumping to next minor version."
-          NEXT_VERSION="v$MINOR"
+          NEXT_VERSION="$MINOR"
         elif [[ $LAST_COMMIT_MESSAGE =~ ^(fix|ci|refactor|chore):.*$ ]]; then
           echo "Bumping to next patch version."
-          NEXT_VERSION="v$PATCH"
+          NEXT_VERSION="$PATCH"
         else
           echo "Skipping version bump."
           NEXT_VERSION="$CURRENT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,19 +45,16 @@ jobs:
     - name: Force fetch tags
       run: git fetch --tags --force
 
-    - name: Find Tag
+    - name: Find last tag
       id: prev-version-tag
-      uses: jimschubert/query-tag-action@v1
-      with:
-        include: '*.*.*'
-        exclude: '*-rc*'
-        commit-ish: 'HEAD~'
-        skip-unshallow: true
+      run: |
+        last_tag=$(git tag -l "*[0-9].*[0-9].*[0-9]*" --sort "-version:refname" | head -n 1)
+        echo "::set-output name=tag::$last_tag"
 
     - name: Find last commit message
       id: last-commit-message
       run: |
-        last_commit_message=$(git log -1 --pretty=%B $BRANCH_NAME --)
+        last_commit_message=$(git log -1 --pretty=%s $BRANCH_NAME --)
         echo "Last commit message found:"
         echo " $last_commit_message"
         echo "LAST_COMMIT_MESSAGE=$last_commit_message" >> $GITHUB_ENV
@@ -84,7 +81,7 @@ jobs:
         elif [[ $LAST_COMMIT_MESSAGE =~ ^feat:.*$ ]]; then
           echo "Bumping to next minor version."
           NEXT_VERSION="v$MINOR"
-        elif [[ $LAST_COMMIT_MESSAGE =~ ^(fix|ci|refactor):.*$ ]]; then
+        elif [[ $LAST_COMMIT_MESSAGE =~ ^(fix|ci|refactor|chore):.*$ ]]; then
           echo "Bumping to next patch version."
           NEXT_VERSION="v$PATCH"
         else
@@ -108,12 +105,6 @@ jobs:
 
     - name: Print build version
       run: echo "Build version will be $BUILD_VERSION"
-    
-    - name: Get changed files using defaults
-      id: changed-files
-      uses: tj-actions/changed-files@v6.3
-      with:
-        fetch-depth: 2
         
     - name: Update project version
       uses: roryprimrose/set-vs-sdk-project-version@v1
@@ -180,6 +171,14 @@ jobs:
         
     # - name: SonarScanner analysis end
     #   run: dotnet sonarscanner end /d:sonar.login=8f9e9412fb5ebcf5ea6f9a6b285b288e4645f866
+
+    - name: Delete build tag if exists
+      uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      with:
+        delete_release: false
+        tag_name: ${{ env.BUILD_VERSION }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set build tag
       uses: anothrNick/github-tag-action@1.26.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,10 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    env:
+      BUILD_VERSION: ${{ github.event.release.tag_name }}
+      NUGET_SOURCE: https://api.nuget.org/v3/index.json
+
     steps:
     - uses: actions/checkout@v2
 
@@ -16,20 +20,29 @@ jobs:
       with:
         dotnet-version: 3.1.x
       
+    - name: Update project version
+      uses: roryprimrose/set-vs-sdk-project-version@v1
+      with:
+        projectFilter: '*.csproj'
+        version: ${{ env.BUILD_VERSION }}
+        assemblyVersion: ${{ env.BUILD_VERSION }}
+        fileVersion: ${{ env.BUILD_VERSION }}
+        informationalVersion: ${{ env.BUILD_VERSION }}
+
     - name: Pack KafkaFlow.Retry
-      run: dotnet pack src/KafkaFlow.Retry/KafkaFlow.Retry.csproj -c Release --include-symbols /p:Version=${{ github.event.release.tag_name }}
+      run: dotnet pack src/KafkaFlow.Retry/KafkaFlow.Retry.csproj -c Release --include-symbols /p:Version=${{ env.BUILD_VERSION }}
           
     - name: Pack KafkaFlow.Retry.API
-      run: dotnet pack src/KafkaFlow.Retry.API/KafkaFlow.Retry.API.csproj -c Release --include-symbols /p:Version=${{ github.event.release.tag_name }}
+      run: dotnet pack src/KafkaFlow.Retry.API/KafkaFlow.Retry.API.csproj -c Release --include-symbols /p:Version=${{ env.BUILD_VERSION }}
       
     - name: Pack KafkaFlow.Retry.SqlServer
-      run: dotnet pack src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj -c Release --include-symbols /p:Version=${{ github.event.release.tag_name }}
+      run: dotnet pack src/KafkaFlow.Retry.SqlServer/KafkaFlow.Retry.SqlServer.csproj -c Release --include-symbols /p:Version=${{ env.BUILD_VERSION }}
       
     - name: Pack KafkaFlow.Retry.MongoDb
-      run: dotnet pack src/KafkaFlow.Retry.MongoDb/KafkaFlow.Retry.MongoDb.csproj -c Release --include-symbols /p:Version=${{ github.event.release.tag_name }}
+      run: dotnet pack src/KafkaFlow.Retry.MongoDb/KafkaFlow.Retry.MongoDb.csproj -c Release --include-symbols /p:Version=${{ env.BUILD_VERSION }}
 
     - name: Publish
-      run: dotnet nuget push ./**/*.nupkg -k ${{ secrets.NUGET_PUBLISH_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+      run: dotnet nuget push ./**/*.nupkg -k ${{ secrets.NUGET_PUBLISH_KEY }} -s ${{ env.NUGET_SOURCE }} --skip-duplicate
 
     - name: Print Version
-      run: echo ${{ github.event.release.tag_name }}
+      run: echo ${{ env.BUILD_VERSION }}


### PR DESCRIPTION
# Description

These changes bring a new step to **Publish** action that fills project (*.csproj) metadata before running `dotnet pack`. **Publish** was also changed to move some values to environment variables.

Also, as this repository's **Build** action shares the build logic with Rules.Framework project, and since that logic has suffered some changes since the build was created, some changes were done:

- Find last tag fails under certain conditions, so step was changed to adopt a new last tag search strategy.
- Find last commit message could fail when having a commit message body with more than 1 line. The %B formatted as full commit message body and the %s formats the commit subject (first line by convention).
- Add chore conventional commit to semantic versioning logic, making it bump patch version number.
- Remove **changed-files** step - not used.
- Add a step to delete tag if it exists before step to set build tag - if version is not bumped, tag will already be assigned to a commit, and trying to set it again will cause the build to fail. This ensures that tag ends up pointing to the last commit it was meant to describe.
- Remove 'v' from semantic versioning tags.

Fixes #16.

## How Has This Been Tested?

Tested using the pull request actions build.

## Checklist

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes (N/A)
-   [ ] I have made corresponding changes to the documentation (N/A)

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
