### PR TITLE
Compress message before publishing

### DIFF
--- a/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddlewareTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddlewareTests.cs
@@ -1,0 +1,45 @@
+﻿namespace KafkaFlow.Retry.UnitTests.KafkaFlow.Retry.Durable
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using global::KafkaFlow.Retry.Durable;
+    using global::KafkaFlow.Retry.Durable.Compression;
+    using Moq;
+    using Xunit;
+
+    public class RetryDurableConsumerCompressorMiddlewareTests
+    {
+        [Fact]
+        internal void RetryDurableConsumerCompressorMiddleware_Ctor_Tests()
+        {
+            // Act
+            Action act = () => new RetryDurableConsumerCompressorMiddleware(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        internal async Task RetryDurableConsumerCompressorMiddleware_Invoke_Tests()
+        {
+            // Arrange
+            var decompressed = new byte[] { 0x20 };
+
+            var mockIGzipCompressor = new Mock<IGzipCompressor>();
+            mockIGzipCompressor
+                .Setup(x => x.Decompress(It.IsAny<byte[]>()))
+                .Returns(decompressed);
+
+            var mockIMessageContext = new Mock<IMessageContext>();
+
+            var compressorMiddleware = new RetryDurableConsumerCompressorMiddleware(mockIGzipCompressor.Object);
+
+            // Act
+            await compressorMiddleware.Invoke(mockIMessageContext.Object, _ => Task.CompletedTask).ConfigureAwait(false);
+
+            // Assert
+            mockIMessageContext.Verify(c => c.SetMessage(null, decompressed), Times.Once);
+        }
+    }
+}

--- a/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerNewtonsoftJsonSerializerMiddlewareTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerNewtonsoftJsonSerializerMiddlewareTests.cs
@@ -1,0 +1,67 @@
+﻿namespace KafkaFlow.Retry.UnitTests.KafkaFlow.Retry.Durable
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using global::KafkaFlow.Retry.Durable;
+    using global::KafkaFlow.Retry.Durable.Serializers;
+    using Moq;
+    using Xunit;
+
+    public class RetryDurableConsumerNewtonsoftJsonSerializerMiddlewareTests
+    {
+        public static IEnumerable<object[]> DataTest()
+        {
+            yield return new object[]
+            {
+                null,
+                typeof(Type)
+            };
+            yield return new object[]
+            {
+                Mock.Of<INewtonsoftJsonSerializer>(),
+                null
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(DataTest))]
+        internal void RetryDurableConsumerNewtonsoftJsonSerializerMiddleware_Ctor_Tests(
+            INewtonsoftJsonSerializer newtonsoftJsonSerializer,
+            Type type)
+        {
+            // Act
+            Action act = () => new RetryDurableConsumerNewtonsoftJsonSerializerMiddleware(
+                newtonsoftJsonSerializer,
+                type);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        internal async Task RetryDurableConsumerNewtonsoftJsonSerializerMiddleware_Invoke_Tests()
+        {
+            // Arrange
+            var deserialized = new { a = 1 };
+
+            var mockINewtonsoftJsonSerializer = new Mock<INewtonsoftJsonSerializer>();
+            mockINewtonsoftJsonSerializer
+                .Setup(x => x.DeserializeObject(It.IsAny<string>(), It.IsAny<Type>()))
+                .Returns(deserialized);
+
+            var mockIMessageContext = new Mock<IMessageContext>();
+
+            var newtonsoftJsonSerializerMiddleware = new RetryDurableConsumerNewtonsoftJsonSerializerMiddleware(
+                mockINewtonsoftJsonSerializer.Object,
+                typeof(Type));
+
+            // Act
+            await newtonsoftJsonSerializerMiddleware.Invoke(mockIMessageContext.Object, _ => Task.CompletedTask).ConfigureAwait(false);
+
+            // Assert
+            mockIMessageContext.Verify(c => c.SetMessage(null, deserialized), Times.Once);
+        }
+    }
+}

--- a/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerUtf8EncoderMiddlewareTests.cs
+++ b/src/KafkaFlow.Retry.UnitTests/KafkaFlow.Retry/Durable/RetryDurableConsumerUtf8EncoderMiddlewareTests.cs
@@ -1,0 +1,45 @@
+﻿namespace KafkaFlow.Retry.UnitTests.KafkaFlow.Retry.Durable
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using global::KafkaFlow.Retry.Durable;
+    using global::KafkaFlow.Retry.Durable.Encoders;
+    using Moq;
+    using Xunit;
+
+    public class RetryDurableConsumerUtf8EncoderMiddlewareTests
+    {
+        [Fact]
+        internal void RetryDurableConsumerUtf8EncoderMiddleware_Ctor_Tests()
+        {
+            // Act
+            Action act = () => new RetryDurableConsumerUtf8EncoderMiddleware(null);
+
+            // Assert
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        internal async Task RetryDurableConsumerUtf8EncoderMiddleware_Invoke_Tests()
+        {
+            // Arrange
+            var decoded = "encoded";
+
+            var mockIUtf8Encoder = new Mock<IUtf8Encoder>();
+            mockIUtf8Encoder
+                .Setup(x => x.Decode(It.IsAny<byte[]>()))
+                .Returns(decoded);
+
+            var mockIMessageContext = new Mock<IMessageContext>();
+
+            var utf8EncoderMiddleware = new RetryDurableConsumerUtf8EncoderMiddleware(mockIUtf8Encoder.Object);
+
+            // Act
+            await utf8EncoderMiddleware.Invoke(mockIMessageContext.Object, _ => Task.CompletedTask).ConfigureAwait(false);
+
+            // Assert
+            mockIMessageContext.Verify(c => c.SetMessage(null, decoded), Times.Once);
+        }
+    }
+}

--- a/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableDefinitionBuilder.cs
+++ b/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableDefinitionBuilder.cs
@@ -119,6 +119,7 @@
                 .Build(
                     this.messageType,
                     retryDurableQueueRepository,
+                    gzipCompressor,
                     utf8Encoder,
                     newtonsoftJsonSerializer,
                     messageAdapter,

--- a/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableEmbeddedClusterDefinitionBuilder.cs
+++ b/src/KafkaFlow.Retry/Durable/Definitions/Builders/RetryDurableEmbeddedClusterDefinitionBuilder.cs
@@ -6,6 +6,7 @@
     using KafkaFlow.Configuration;
     using KafkaFlow.Producers;
     using KafkaFlow.Retry.Durable;
+    using KafkaFlow.Retry.Durable.Compression;
     using KafkaFlow.Retry.Durable.Definitions;
     using KafkaFlow.Retry.Durable.Encoders;
     using KafkaFlow.Retry.Durable.Polling;
@@ -69,6 +70,7 @@
         internal void Build(
             Type messageType,
             IRetryDurableQueueRepository retryDurableQueueRepository,
+            IGzipCompressor gzipCompressor,
             IUtf8Encoder utf8Encoder,
             INewtonsoftJsonSerializer newtonsoftJsonSerializer,
             IMessageAdapter messageAdapter,
@@ -139,6 +141,7 @@
                             })
                         .AddMiddlewares(
                             middlewares => middlewares
+                                .Add(resolver => new RetryDurableConsumerCompressorMiddleware(gzipCompressor))
                                 .Add(resolver => new RetryDurableConsumerUtf8EncoderMiddleware(utf8Encoder))
                                 .Add(resolver => new RetryDurableConsumerNewtonsoftJsonSerializerMiddleware(newtonsoftJsonSerializer, messageType))
                                 .WithRetryConsumerStrategy(this.retryConusmerStrategy, retryDurableQueueRepository, utf8Encoder)

--- a/src/KafkaFlow.Retry/Durable/Polling/QueuePollingJob.cs
+++ b/src/KafkaFlow.Retry/Durable/Polling/QueuePollingJob.cs
@@ -63,7 +63,7 @@
             {
                 logHandler.Info(
                     "PollingJob starts execution",
-                    new 
+                    new
                     {
                         Name = context.Trigger.Key.Name
                     }
@@ -143,7 +143,7 @@
                             await retryDurableProducer
                                 .ProduceAsync(
                                     item.Message.Key,
-                                    messageAdapter.AdaptMessageFromRepository(item.Message.Value),
+                                    item.Message.Value,
                                     this.GetMessageHeaders(messageHeadersAdapter, utf8Encoder, queue.Id, item)
                                 ).ConfigureAwait(false);
 
@@ -162,9 +162,9 @@
                         catch (Exception ex)
                         {
                             logHandler.Error(
-                                "Exception on queue PollingJob execution producing to retry topic", 
-                                ex, 
-                                new 
+                                "Exception on queue PollingJob execution producing to retry topic",
+                                ex,
+                                new
                                 {
                                     ItemId = item.Id,
                                     QueueId = queue.Id
@@ -173,7 +173,7 @@
                             await retryDurableQueueRepository
                                 .UpdateItemAsync(
                                     new UpdateItemStatusInput(
-                                        item.Id, 
+                                        item.Id,
                                         RetryQueueItemStatus.Waiting))
                                 .ConfigureAwait(false);
 

--- a/src/KafkaFlow.Retry/Durable/Repository/Adapters/IMessageAdapter.cs
+++ b/src/KafkaFlow.Retry/Durable/Repository/Adapters/IMessageAdapter.cs
@@ -2,8 +2,6 @@
 {
     internal interface IMessageAdapter
     {
-        byte[] AdaptMessageFromRepository(byte[] message);
-
         byte[] AdaptMessageToRepository(object message);
     }
 }

--- a/src/KafkaFlow.Retry/Durable/Repository/Adapters/NewtonsoftJsonMessageAdapter.cs
+++ b/src/KafkaFlow.Retry/Durable/Repository/Adapters/NewtonsoftJsonMessageAdapter.cs
@@ -20,11 +20,6 @@
             this.utf8Encoder = utf8Encoder;
         }
 
-        public byte[] AdaptMessageFromRepository(byte[] message)
-        {
-            return this.gzipCompressor.Decompress(message);
-        }
-
         public byte[] AdaptMessageToRepository(object message)
         {
             var messageSerialized = this.newtonsoftJsonSerializer.SerializeObject(message);

--- a/src/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddleware.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddleware.cs
@@ -1,0 +1,20 @@
+﻿namespace KafkaFlow.Retry.Durable
+{
+    using System.Threading.Tasks;
+    using KafkaFlow.Retry.Durable.Compression;
+
+    internal class RetryDurableConsumerCompressorMiddleware : IMessageMiddleware
+    {
+        private readonly IGzipCompressor gzipCompressor;
+
+        public RetryDurableConsumerCompressorMiddleware(IGzipCompressor gzipCompressor)
+        {
+            this.gzipCompressor = gzipCompressor;
+        }
+
+        public async Task Invoke(IMessageContext context, MiddlewareDelegate next)
+        {
+            await next(context.SetMessage(context.Message.Key, this.gzipCompressor.Decompress((byte[])context.Message.Value))).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddleware.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryDurableConsumerCompressorMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿namespace KafkaFlow.Retry.Durable
 {
     using System.Threading.Tasks;
+    using Dawn;
     using KafkaFlow.Retry.Durable.Compression;
 
     internal class RetryDurableConsumerCompressorMiddleware : IMessageMiddleware
@@ -9,6 +10,8 @@
 
         public RetryDurableConsumerCompressorMiddleware(IGzipCompressor gzipCompressor)
         {
+            Guard.Argument(gzipCompressor).NotNull();
+
             this.gzipCompressor = gzipCompressor;
         }
 

--- a/src/KafkaFlow.Retry/Durable/RetryDurableConsumerNewtonsoftJsonSerializerMiddleware.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryDurableConsumerNewtonsoftJsonSerializerMiddleware.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Threading.Tasks;
+    using Dawn;
     using KafkaFlow.Retry.Durable.Serializers;
 
     internal class RetryDurableConsumerNewtonsoftJsonSerializerMiddleware : IMessageMiddleware
@@ -11,7 +12,11 @@
 
         public RetryDurableConsumerNewtonsoftJsonSerializerMiddleware(INewtonsoftJsonSerializer newtonsoftJsonSerializer, Type type)
         {
-            this.newtonsoftJsonSerializer = newtonsoftJsonSerializer; this.type = type;
+            Guard.Argument(newtonsoftJsonSerializer).NotNull();
+            Guard.Argument(type).NotNull();
+
+            this.newtonsoftJsonSerializer = newtonsoftJsonSerializer;
+            this.type = type;
         }
 
         public async Task Invoke(IMessageContext context, MiddlewareDelegate next)

--- a/src/KafkaFlow.Retry/Durable/RetryDurableConsumerUtf8EncoderMiddleware.cs
+++ b/src/KafkaFlow.Retry/Durable/RetryDurableConsumerUtf8EncoderMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿namespace KafkaFlow.Retry.Durable
 {
     using System.Threading.Tasks;
+    using Dawn;
     using KafkaFlow.Retry.Durable.Encoders;
 
     internal class RetryDurableConsumerUtf8EncoderMiddleware : IMessageMiddleware
@@ -9,6 +10,8 @@
 
         public RetryDurableConsumerUtf8EncoderMiddleware(IUtf8Encoder utf8Encoder)
         {
+            Guard.Argument(utf8Encoder).NotNull();
+
             this.utf8Encoder = utf8Encoder;
         }
 


### PR DESCRIPTION
# Description

It was avoided the decompress of a message when it is loaded from a repository and is published on the topic. It was added middleware on the retry consumer to decompress de message.

Fixes #73 

## How Has This Been Tested?

Integrations tests

## Checklist

-   [X] My code follows the style guidelines of this project
-   [X] I have performed a self-review of my own code
-   [ ] I have added tests to cover my changes
-   [ ] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)
