### PR TITLE
feat: include mongodb retry skip index creation parameter

### DIFF
--- a/src/KafkaFlow.Retry.MongoDb/MongoDbDataProviderFactory.cs
+++ b/src/KafkaFlow.Retry.MongoDb/MongoDbDataProviderFactory.cs
@@ -23,7 +23,12 @@ public sealed class MongoDbDataProviderFactory
         {
             var mongoClient = new MongoClient(mongoDbSettings.ConnectionString);
             var dbContext = new DbContext(mongoDbSettings, mongoClient);
-            DboConfigurations.TryAddIndexes(dbContext);
+
+            if (!mongoDbSettings.SkipIndexCreation)
+            {
+                DboConfigurations.TryAddIndexes(dbContext);
+            }
+
             return new DataProviderCreationResult(
                 null,
                 new RetryQueueDataProvider(

--- a/src/KafkaFlow.Retry.MongoDb/MongoDbSettings.cs
+++ b/src/KafkaFlow.Retry.MongoDb/MongoDbSettings.cs
@@ -5,6 +5,8 @@ namespace KafkaFlow.Retry.MongoDb;
 [ExcludeFromCodeCoverage]
 public class MongoDbSettings
 {
+    public bool SkipIndexCreation { get; set; }
+
     public string ConnectionString { get; set; }
 
     public string DatabaseName { get; set; }

--- a/src/KafkaFlow.Retry.MongoDb/RetryDurableDefinitionBuilderExtension.cs
+++ b/src/KafkaFlow.Retry.MongoDb/RetryDurableDefinitionBuilderExtension.cs
@@ -9,10 +9,29 @@ public static class RetryDurableDefinitionBuilderExtension
         string mongoDbretryQueueCollectionName,
         string mongoDbretryQueueItemCollectionName)
     {
+        return WithMongoDbDataProvider(
+            retryDurableDefinitionBuilder,
+            connectionString,
+            databaseName,
+            mongoDbretryQueueCollectionName,
+            mongoDbretryQueueItemCollectionName,
+            mongoDbretrySkipIndexCreation: false
+        );
+    }
+
+    public static RetryDurableDefinitionBuilder WithMongoDbDataProvider(
+        this RetryDurableDefinitionBuilder retryDurableDefinitionBuilder,
+        string connectionString,
+        string databaseName,
+        string mongoDbretryQueueCollectionName,
+        string mongoDbretryQueueItemCollectionName,
+        bool mongoDbretrySkipIndexCreation)
+    {
         var dataProviderCreation = new MongoDbDataProviderFactory()
             .TryCreate(
                 new MongoDbSettings
                 {
+                    SkipIndexCreation = mongoDbretrySkipIndexCreation,
                     ConnectionString = connectionString,
                     DatabaseName = databaseName,
                     RetryQueueCollectionName = mongoDbretryQueueCollectionName,

--- a/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/RetryDurableDefinitionBuilderExtensionTests.cs
+++ b/tests/KafkaFlow.Retry.UnitTests/Repositories/MongoDb/RetryDurableDefinitionBuilderExtensionTests.cs
@@ -40,4 +40,23 @@ public class RetryDurableDefinitionBuilderExtensionTests
         result.Should().NotBeNull();
         result.Should().BeOfType(typeof(RetryDurableDefinitionBuilder));
     }
+    
+    [Fact]
+    public void RetryDurableDefinitionBuilder_WithMongoDbDataProviderAndSkipIndexCreation_Success()
+    {
+        // Arrange
+        var builder = new RetryDurableDefinitionBuilder();
+
+        // Act
+        var result = builder.WithMongoDbDataProvider(
+            "mongodb://localhost:27017/KafkaFlowRetry?maxPoolSize=1000",
+            "Test",
+            "RetryQueueCollectionName",
+            "RetryQueueItemCollectionName",
+            true
+        );
+
+        result.Should().NotBeNull();
+        result.Should().BeOfType(typeof(RetryDurableDefinitionBuilder));
+    }
 }

--- a/website/docs/guides/durable-retries.md
+++ b/website/docs/guides/durable-retries.md
@@ -132,12 +132,15 @@ On the configuration, define the access configuration to the MongoDb instance.
                 connectionString,
                 database,
                 retryQueueCollectionName,
-                retryQueueItemCollectionName)
+                retryQueueItemCollectionName,
+                retrySkipIndexCreation)
             ...
     )
     ...
 )
 ```
+
+- `retrySkipIndexCreation`: When this parameter is included, the application will ignore the creation of its indexes.
 
 
 ## How to use SQL Server as a Provider


### PR DESCRIPTION
## Description

This PR introduces a new configuration parameter that allows developers to explicitly skip automatic MongoDB index creation in **KafkaFlow\.Retry.MongoDb**.

By setting this option, the library will create collections but will not enforce index creation. This provides greater flexibility in environments where indexes are managed externally (e.g., via migrations, DevOps pipelines, or centralized governance).

Fixes #161

## Motivation and Context

Currently, indexes are automatically created through `DboConfigurations.TryAddIndexes`. While convenient in development, this behavior may conflict with existing database policies in production environments.

The new parameter makes index management explicit, giving developers control and avoiding duplicate or conflicting index definitions.

## How Has This Been Tested?

* Unit tests were added to validate that:

  * Indexes are created when the parameter is not set (default behavior).
  * Index creation is skipped when the parameter is enabled.
* Integration tests confirm that collections are still created and functional even when index creation is disabled.

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have added tests to cover my changes
* [x] I have made corresponding changes to the documentation

### Disclaimer

By sending us your contributions, you are agreeing that your contribution is made subject to the terms of our [[Contributor Ownership Statement](https://github.com/Farfetch/.github/blob/master/COS.md)](https://github.com/Farfetch/.github/blob/master/COS.md)
